### PR TITLE
Need access to glue DBs

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_buckets"></a> [buckets](#input\_buckets) | The ARNs of the AWS S3 buckets the policy is allowed to read from.  Use ["*"] to allow all buckets. | `list(string)` | `[]` | no |
+| <a name="input_databases"></a> [databases](#input\_databases) | The ARNs of the AWS Glue Databases.  Use ["*"] to allow all databases. | `list(string)` | `[]` | no |
 | <a name="input_description"></a> [description](#input\_description) | The description of the AWS IAM policy. | `string` | `""` | no |
 | <a name="input_keys"></a> [keys](#input\_keys) | The ARNs of the AWS KMS keys the policy is allowed to use to decrypt files.  Use ["*"] to allow all keys. | `list(string)` | `[]` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name of the AWS IAM policy. | `string` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -77,6 +77,15 @@ data "aws_iam_policy_document" "main" {
     resources = length(var.keys) > 0 ? var.keys : ["*"]
   }
 
+  statement {
+    sid = "GetTable"
+    actions = [
+      "glue:*",
+    ]
+    effect    = length(var.databases) > 0 ? "Allow" : "Deny"
+    resources = length(var.databases) > 0 ? var.databases : ["*"]
+  }
+
 }
 
 resource "aws_iam_policy" "main" {

--- a/variables.tf
+++ b/variables.tf
@@ -16,6 +16,12 @@ variable "keys" {
   default     = []
 }
 
+variable "databases" {
+  type        = list(string)
+  description = "The ARNs of the AWS Glue Databases.  Use [\"*\"] to allow all databases."
+  default     = []
+}
+
 variable "name" {
   type        = string
   description = "The name of the AWS IAM policy."


### PR DESCRIPTION
Without this change the policy didn't give access to the glue resources needed to view glue tables in console. In hindsight, for a data scientist to use this they don't really need this, but without it aws console for glue is pretty useless. Is this a valid addition to this policy?